### PR TITLE
When we reload databases post-release to public MySQL server, we need…

### DIFF
--- a/modules/Bio/EnsEMBL/DBLoader/RunnableDB/DownloadDatabase.pm
+++ b/modules/Bio/EnsEMBL/DBLoader/RunnableDB/DownloadDatabase.pm
@@ -130,7 +130,7 @@ sub _rsync_download {
   $rsync_url .= "/mysql/${database}";
 
   my $verbose = ( $self->debug() ) ? '--verbose' : '--quiet';
-  my $cmd = "rsync --recursive $verbose $rsync_url .";
+  my $cmd = "rsync --recursive --delete $verbose $rsync_url .";
   $self->_create_local_dir( 0, $database );
   print STDERR "Running: $cmd\n" if $self->debug();
   system($cmd);


### PR DESCRIPTION
… to make sure that we don't reload tables that have been removed